### PR TITLE
[codex] fix Actions CI type and headless gates

### DIFF
--- a/packages/cli/src/acp/index.ts
+++ b/packages/cli/src/acp/index.ts
@@ -18,7 +18,7 @@ import { BladeAgent } from './BladeAgent.js';
 export async function runAcpIntegration(): Promise<void> {
   // 使用 Web Streams API 包装 Node.js streams
   const stdout = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
-  const stdin = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
+  const stdin = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
 
   // 创建 ndJSON 流（换行分隔的 JSON）
   const stream = acp.ndJsonStream(stdout, stdin);

--- a/packages/cli/src/commands/print.ts
+++ b/packages/cli/src/commands/print.ts
@@ -32,7 +32,7 @@ interface PrintOptions {
   maxTurns?: number;
   sessionId?: string;
   continue?: boolean;
-  resume?: string;
+  resume?: string | boolean;
   allowedTools?: string[];
   disallowedTools?: string[];
   mcpConfig?: string[];

--- a/packages/cli/src/hooks/HookConfig.ts
+++ b/packages/cli/src/hooks/HookConfig.ts
@@ -4,7 +4,7 @@
  * 默认配置和配置加载逻辑
  */
 
-import { HookType, type HookConfig } from './types/HookTypes.js';
+import { type HookConfig, HookType } from './types/HookTypes.js';
 
 /**
  * 默认 Hook 配置
@@ -16,6 +16,7 @@ export const DEFAULT_HOOK_CONFIG: Required<HookConfig> = {
   timeoutBehavior: 'ignore', // 超时时忽略,继续执行
   failureBehavior: 'ignore', // 失败时忽略,继续执行
   maxConcurrentHooks: 5, // 最多 5 个并发 hook
+  httpPolicy: {},
   // 工具执行类
   PreToolUse: [],
   PostToolUse: [

--- a/packages/cli/src/types/node-pty.d.ts
+++ b/packages/cli/src/types/node-pty.d.ts
@@ -1,0 +1,22 @@
+declare module 'node-pty' {
+  interface PtyProcess {
+    pid: number;
+    write(data: string): void;
+    resize(cols: number, rows: number): void;
+    kill(signal?: string): void;
+    onData(callback: (data: string) => void): void;
+    onExit(callback: (event: { exitCode: number }) => void): void;
+  }
+
+  export function spawn(
+    command: string,
+    args: string[] | string,
+    options: {
+      name?: string;
+      cwd?: string;
+      env?: Record<string, string | undefined>;
+      cols?: number;
+      rows?: number;
+    }
+  ): PtyProcess;
+}

--- a/packages/cli/tests/support/setup.ts
+++ b/packages/cli/tests/support/setup.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeAll, vi } from 'vitest';
 
 // 模拟 Node.js 的 fetch API
 if (!global.fetch) {
-  global.fetch = vi.fn();
+  global.fetch = vi.fn() as unknown as typeof fetch;
 }
 
 // 测试环境配置

--- a/packages/cli/tests/unit/agent-runtime/agent/execute-loop-generator.test.ts
+++ b/packages/cli/tests/unit/agent-runtime/agent/execute-loop-generator.test.ts
@@ -765,7 +765,7 @@ describe('executeLoopGenerator', () => {
       expect(contextMgr.saveMessage.mock.calls).toHaveLength(4);
       expect(
         contextMgr.saveMessage.mock.calls.map(
-          ([sessionId, role, content, parentUuid]: [string, string, unknown, string | null]) => ({
+          ([sessionId, role, content, parentUuid]) => ({
             sessionId,
             role,
             content,
@@ -844,7 +844,7 @@ describe('executeLoopGenerator', () => {
       expect(contextMgr.saveMessage.mock.calls).toHaveLength(4);
       expect(
         contextMgr.saveMessage.mock.calls.map(
-          ([sessionId, role, content, parentUuid]: [string, string, unknown, string | null]) => ({
+          ([sessionId, role, content, parentUuid]) => ({
             sessionId,
             role,
             content,
@@ -919,7 +919,7 @@ describe('executeLoopGenerator', () => {
       expect(contextMgr.saveMessage.mock.calls).toHaveLength(4);
       expect(
         contextMgr.saveMessage.mock.calls.map(
-          ([sessionId, role, content, parentUuid]: [string, string, unknown, string | null]) => ({
+          ([sessionId, role, content, parentUuid]) => ({
             sessionId,
             role,
             content,

--- a/packages/cli/tests/unit/agent-runtime/agent/subagent-event-forwarding.test.ts
+++ b/packages/cli/tests/unit/agent-runtime/agent/subagent-event-forwarding.test.ts
@@ -125,9 +125,13 @@ describe('SubagentExecutor event forwarding', () => {
   });
 
   it('returns failure result when generator throws', async () => {
-    mockChatStream.mockImplementation(async function* () {
+    mockChatStream.mockImplementation(async function* (): AsyncGenerator<
+      LoopEvent,
+      LoopResult,
+      void
+    > {
       if (Date.now() < 0) {
-        yield undefined;
+        yield { kind: 'stream_end' };
       }
       throw new Error('model overloaded');
     });

--- a/packages/cli/tests/unit/agent-runtime/agent/subagent-registry.test.ts
+++ b/packages/cli/tests/unit/agent-runtime/agent/subagent-registry.test.ts
@@ -6,16 +6,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SubagentRegistry } from '../../../../src/agent/subagents/SubagentRegistry.js';
 
 // Mock fs and path
-vi.mock('node:fs', () => ({
-  default: {
-    existsSync: vi.fn(),
-    readdirSync: vi.fn(),
-    readFileSync: vi.fn(),
-  },
-  existsSync: vi.fn(),
-  readdirSync: vi.fn(),
-  readFileSync: vi.fn(),
-}));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const existsSync = vi.fn();
+  const readdirSync = vi.fn();
+  const readFileSync = vi.fn();
+
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync,
+      readdirSync,
+      readFileSync,
+    },
+    existsSync,
+    readdirSync,
+    readFileSync,
+  };
+});
 
 import fs from 'node:fs';
 

--- a/packages/cli/tests/unit/backgroundTaskManager.test.ts
+++ b/packages/cli/tests/unit/backgroundTaskManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BackgroundTaskManager } from '../../src/utils/backgroundTaskManager';
 
 describe('BackgroundTaskManager - 后台任务管理器', () => {
@@ -14,6 +14,8 @@ describe('BackgroundTaskManager - 后台任务管理器', () => {
 		for (const task of tasks) {
 			manager.deleteTask(task.id);
 		}
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 	});
 
 	describe('createTask - 创建任务', () => {
@@ -201,17 +203,25 @@ describe('BackgroundTaskManager - 后台任务管理器', () => {
 
 	describe('killTask - 终止任务', () => {
 		it('应该标记正在运行的任务为已终止', async () => {
+			vi.useFakeTimers();
+			const killSpy = vi
+				.spyOn(process, 'kill')
+				.mockImplementation(() => true);
 			const taskId = manager.createTask({
 				command: 'sleep 1000',
-				pid: process.pid, // 使用当前进程 pid 进行测试
+				pid: process.pid,
 			});
 
-			const killed = await manager.killTask(taskId);
+			const killPromise = manager.killTask(taskId);
+			await vi.advanceTimersByTimeAsync(200);
+			const killed = await killPromise;
 
-			// 在测试环境中可能无法真正终止进程
-			// 但应该标记状态
 			const task = manager.getTask(taskId);
-			expect(task?.status).toMatch(/killed|failed/);
+			expect(killed).toBe(true);
+			expect(task?.status).toBe('killed');
+			expect(killSpy).toHaveBeenCalledWith(-process.pid, 'SIGTERM');
+			expect(killSpy).toHaveBeenCalledWith(process.pid, 0);
+			expect(killSpy).toHaveBeenCalledWith(-process.pid, 'SIGKILL');
 		});
 
 		it('非运行状态的任务不应该被终止', async () => {

--- a/packages/cli/tests/unit/cli/commands/print.test.ts
+++ b/packages/cli/tests/unit/cli/commands/print.test.ts
@@ -93,7 +93,7 @@ describe('print command runner', () => {
         disallowedTools: ['Write'],
         permissionMode: 'default',
       },
-      { stdout, stderr } as typeof process
+      { stdout, stderr } as unknown as Pick<typeof process, 'stdout' | 'stderr'>
     );
 
     expect(exitCode).toBe(0);
@@ -145,7 +145,7 @@ describe('print command runner', () => {
         print: true,
         message: '/help',
       },
-      { stdout, stderr } as typeof process
+      { stdout, stderr } as unknown as Pick<typeof process, 'stdout' | 'stderr'>
     );
 
     expect(exitCode).toBe(0);
@@ -169,7 +169,7 @@ describe('print command runner', () => {
         message: 'hello',
         resume: true,
       },
-      { stdout, stderr } as typeof process
+      { stdout, stderr } as unknown as Pick<typeof process, 'stdout' | 'stderr'>
     );
 
     expect(exitCode).toBe(1);

--- a/packages/cli/tests/unit/hooks/function-hook.test.ts
+++ b/packages/cli/tests/unit/hooks/function-hook.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PermissionMode } from '../../../src/config/types.js';
 import { HookManager } from '../../../src/hooks/HookManager.js';
 import {
+  DecisionBehavior,
   HookEvent,
   HookType,
 } from '../../../src/hooks/types/HookTypes.js';
@@ -51,7 +52,7 @@ describe('Function Hook', () => {
         HookEvent.PreToolUse,
         { tools: 'Edit' },
         async () => ({
-          decision: { behavior: 'block' },
+          decision: { behavior: DecisionBehavior.Block },
           systemMessage: 'nope',
         })
       );

--- a/packages/cli/tests/unit/platform/services/models-dev-service.test.ts
+++ b/packages/cli/tests/unit/platform/services/models-dev-service.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+global.fetch = mockFetch as unknown as typeof fetch;
 
 vi.mock('@/logging/Logger.js', () => ({
   createLogger: () => ({

--- a/packages/cli/tests/unit/platform/ui/ChatStatusBar.test.tsx
+++ b/packages/cli/tests/unit/platform/ui/ChatStatusBar.test.tsx
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockUseGitBranch = vi.fn(() => ({ branch: 'main', loading: false }));
+const mockUseGitBranch = vi.fn((_projectRoot?: string) => ({
+  branch: 'main',
+  loading: false,
+}));
 const mockGetProjectRoot = vi.fn(() => '/repo-root');
 
 vi.mock('../../../../src/store/selectors/index.js', () => ({
@@ -16,7 +19,7 @@ vi.mock('../../../../src/store/selectors/index.js', () => ({
 }));
 
 vi.mock('../../../../src/ui/hooks/useGitBranch.js', () => ({
-  useGitBranch: (...args: unknown[]) => mockUseGitBranch(...args),
+  useGitBranch: (projectRoot?: string) => mockUseGitBranch(projectRoot),
 }));
 
 vi.mock('../../../../src/bootstrap/state.js', () => ({
@@ -31,7 +34,7 @@ describe('ChatStatusBar', () => {
 
   it('应该使用稳定 projectRoot 获取分支', async () => {
     const { ChatStatusBar } = await import(
-      '../../../../src/ui/components/ChatStatusBar.tsx'
+      '../../../../src/ui/components/ChatStatusBar.js'
     );
 
     const render = (ChatStatusBar as unknown as { type: () => unknown }).type;

--- a/packages/cli/tests/unit/platform/ui/ChatStatusBar.test.tsx
+++ b/packages/cli/tests/unit/platform/ui/ChatStatusBar.test.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockUseGitBranch = vi.fn((_projectRoot?: string) => ({
@@ -5,6 +7,13 @@ const mockUseGitBranch = vi.fn((_projectRoot?: string) => ({
   loading: false,
 }));
 const mockGetProjectRoot = vi.fn(() => '/repo-root');
+
+vi.mock('ink', () => ({
+  Box: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  Text: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('span', null, children),
+}));
 
 vi.mock('../../../../src/store/selectors/index.js', () => ({
   useActiveModal: () => null,
@@ -37,8 +46,7 @@ describe('ChatStatusBar', () => {
       '../../../../src/ui/components/ChatStatusBar.js'
     );
 
-    const render = (ChatStatusBar as unknown as { type: () => unknown }).type;
-    render();
+    renderToStaticMarkup(React.createElement(ChatStatusBar));
 
     expect(mockGetProjectRoot).toHaveBeenCalledTimes(1);
     expect(mockUseGitBranch).toHaveBeenCalledWith('/repo-root');

--- a/packages/cli/tests/unit/platform/ui/LoadingIndicator.test.tsx
+++ b/packages/cli/tests/unit/platform/ui/LoadingIndicator.test.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockUseLoadingIndicator = vi.fn(() => ({
-  currentPhrase: '炼化代码灵气...',
-  elapsedTime: 0,
-}));
+const mockUseLoadingIndicator = vi.fn(
+  (_isProcessing?: boolean, _isWaiting?: boolean, _paused?: boolean) => ({
+    currentPhrase: '炼化代码灵气...',
+    elapsedTime: 0,
+  })
+);
 const mockUseTerminalWidth = vi.fn(() => 120);
 
 vi.mock('ink', () => ({
@@ -30,7 +32,11 @@ vi.mock('../../../../src/store/selectors/index.js', () => ({
 }));
 
 vi.mock('../../../../src/ui/hooks/useLoadingIndicator.js', () => ({
-  useLoadingIndicator: (...args: unknown[]) => mockUseLoadingIndicator(...args),
+  useLoadingIndicator: (
+    isProcessing?: boolean,
+    isWaiting?: boolean,
+    paused?: boolean
+  ) => mockUseLoadingIndicator(isProcessing, isWaiting, paused),
 }));
 
 vi.mock('../../../../src/ui/hooks/useTerminalWidth.js', () => ({
@@ -50,7 +56,7 @@ describe('LoadingIndicator', () => {
 
   it('短时间加载时应该优先显示中性文案而不是趣味短语', async () => {
     const { LoadingIndicator } = await import(
-      '../../../../src/ui/components/LoadingIndicator.tsx'
+      '../../../../src/ui/components/LoadingIndicator.js'
     );
 
     const html = renderToStaticMarkup(

--- a/packages/cli/tests/unit/platform/utils/proxy-fetch.test.ts
+++ b/packages/cli/tests/unit/platform/utils/proxy-fetch.test.ts
@@ -2,54 +2,110 @@
  * proxyFetch 工具函数测试
  */
 
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const undiciMocks = vi.hoisted(() => {
+  const agents: Array<{ proxyUrl: string }> = [];
+
+  return {
+    agents,
+    fetch: vi.fn(),
+    ProxyAgent: vi.fn(function (this: { proxyUrl: string }, proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+      agents.push(this);
+    }),
+  };
+});
+
+vi.mock('undici', () => ({
+  fetch: undiciMocks.fetch,
+  ProxyAgent: undiciMocks.ProxyAgent,
+}));
+
 import { proxyFetch } from '../../../../src/utils/proxyFetch.js';
 
-// 保存原始环境变量
-const originalEnv = { ...process.env };
+const proxyEnvKeys = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+] as const;
+const originalProxyEnv = Object.fromEntries(
+  proxyEnvKeys.map((key) => [key, process.env[key]])
+);
 
-const expectOkOrNetworkError = async (promise: Promise<Response>) => {
-  try {
-    const response = await promise;
-    expect(response.ok).toBe(true);
-  } catch (error) {
-    expect(error).toBeInstanceOf(Error);
-  }
-};
+function abortableRequest(
+  _url: string,
+  options: { signal?: AbortSignal }
+): Promise<Response> {
+  return new Promise((_resolve, reject) => {
+    options.signal?.addEventListener(
+      'abort',
+      () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+      { once: true }
+    );
+  });
+}
 
 describe('proxyFetch', () => {
   beforeEach(() => {
-    // 重置环境变量
-    process.env.HTTP_PROXY = undefined;
-    process.env.HTTPS_PROXY = undefined;
-    process.env.http_proxy = undefined;
-    process.env.https_proxy = undefined;
+    for (const key of proxyEnvKeys) {
+      delete process.env[key];
+    }
+    undiciMocks.agents.length = 0;
+    undiciMocks.ProxyAgent.mockClear();
+    undiciMocks.fetch.mockReset();
+    undiciMocks.fetch.mockResolvedValue(new Response('ok'));
   });
 
   afterEach(() => {
-    // 恢复原始环境变量
-    process.env = { ...originalEnv };
-    vi.restoreAllMocks();
+    for (const key of proxyEnvKeys) {
+      const value = originalProxyEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.useRealTimers();
   });
 
   describe('基本功能', () => {
     it('应该能够发起 GET 请求', async () => {
-      await expectOkOrNetworkError(proxyFetch('https://httpbin.org/get'));
+      const response = await proxyFetch('https://example.test/get');
+
+      expect(response.ok).toBe(true);
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'https://example.test/get',
+        expect.objectContaining({ dispatcher: undefined })
+      );
     });
 
     it('应该能够发起 POST 请求', async () => {
-      await expectOkOrNetworkError(
-        proxyFetch('https://httpbin.org/post', {
+      await proxyFetch('https://example.test/post', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      });
+
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'https://example.test/post',
+        expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ test: 'data' }),
+          body: '{"test":"data"}',
         })
       );
     });
 
     it('应该支持自定义 headers', async () => {
-      await expectOkOrNetworkError(
-        proxyFetch('https://httpbin.org/headers', {
+      await proxyFetch('https://example.test/headers', {
+        headers: { 'X-Custom-Header': 'test-value' },
+      });
+
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'https://example.test/headers',
+        expect.objectContaining({
           headers: { 'X-Custom-Header': 'test-value' },
         })
       );
@@ -58,13 +114,27 @@ describe('proxyFetch', () => {
 
   describe('超时处理', () => {
     it('应该在超时后抛出错误', async () => {
-      await expect(
-        proxyFetch('https://httpbin.org/delay/10', { timeout: 100 })
+      vi.useFakeTimers();
+      undiciMocks.fetch.mockImplementationOnce(abortableRequest);
+
+      const assertion = expect(
+        proxyFetch('https://example.test/slow', { timeout: 100 })
       ).rejects.toThrow('Request timeout after 100ms');
+      await vi.advanceTimersByTimeAsync(100);
+
+      await assertion;
     });
 
     it('应该使用默认超时时间 (30s)', async () => {
-      await expectOkOrNetworkError(proxyFetch('https://httpbin.org/delay/1'));
+      vi.useFakeTimers();
+      undiciMocks.fetch.mockImplementationOnce(abortableRequest);
+
+      const assertion = expect(proxyFetch('https://example.test/slow')).rejects.toThrow(
+        'Request timeout after 30000ms'
+      );
+      await vi.advanceTimersByTimeAsync(30000);
+
+      await assertion;
     });
   });
 
@@ -74,8 +144,9 @@ describe('proxyFetch', () => {
       controller.abort();
 
       await expect(
-        proxyFetch('https://httpbin.org/get', { signal: controller.signal })
+        proxyFetch('https://example.test/get', { signal: controller.signal })
       ).rejects.toThrow('The operation was aborted.');
+      expect(undiciMocks.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -83,42 +154,57 @@ describe('proxyFetch', () => {
     it('应该正确处理 HTTPS_PROXY 环境变量', async () => {
       process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
 
-      // 这个测试只是验证代码不会因为无效代理 URL 而崩溃
-      // 实际的代理连接需要在有代理服务器的环境中测试
-      // 在没有实际代理的情况下，请求会失败，但不应该因为代理配置而崩溃
-      await expect(
-        proxyFetch('https://httpbin.org/get')
-      ).rejects.toThrow();
+      await proxyFetch('https://example.test/get');
+
+      expect(undiciMocks.ProxyAgent).toHaveBeenCalledWith(
+        'http://proxy.example.com:8080'
+      );
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'https://example.test/get',
+        expect.objectContaining({ dispatcher: undiciMocks.agents[0] })
+      );
     });
 
     it('应该正确处理 HTTP_PROXY 环境变量', async () => {
       process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
 
-      // 同样的，只是验证代码不会崩溃
-      await expect(
-        proxyFetch('https://httpbin.org/get')
-      ).rejects.toThrow();
+      await proxyFetch('http://example.test/get');
+
+      expect(undiciMocks.ProxyAgent).toHaveBeenCalledWith(
+        'http://proxy.example.com:8080'
+      );
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'http://example.test/get',
+        expect.objectContaining({ dispatcher: undiciMocks.agents[0] })
+      );
     });
   });
 
   describe('错误处理', () => {
     it('应该处理网络错误', async () => {
-      await expect(
-        proxyFetch('https://this-domain-does-not-exist-12345.com')
-      ).rejects.toThrow();
+      undiciMocks.fetch.mockRejectedValueOnce(new Error('network error'));
+
+      await expect(proxyFetch('https://example.test')).rejects.toThrow('network error');
     });
 
     it('应该处理无效的 URL', async () => {
-      await expect(
-        proxyFetch('not-a-valid-url')
-      ).rejects.toThrow();
+      undiciMocks.fetch.mockRejectedValueOnce(new TypeError('Invalid URL'));
+
+      await expect(proxyFetch('not-a-valid-url')).rejects.toThrow('Invalid URL');
     });
   });
 
   describe('选项传递', () => {
     it('应该支持 fetch 标准选项', async () => {
-      await expectOkOrNetworkError(
-        proxyFetch('https://httpbin.org/put', {
+      await proxyFetch('https://example.test/put', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'test data',
+      });
+
+      expect(undiciMocks.fetch).toHaveBeenCalledWith(
+        'https://example.test/put',
+        expect.objectContaining({
           method: 'PUT',
           headers: { 'Content-Type': 'text/plain' },
           body: 'test data',
@@ -127,17 +213,24 @@ describe('proxyFetch', () => {
     });
 
     it('应该处理 JSON 响应', async () => {
-      const response = await proxyFetch('https://httpbin.org/json');
+      undiciMocks.fetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: 'ok' }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      const response = await proxyFetch('https://example.test/json');
       const data = await response.json();
-      expect(data).toBeDefined();
-      expect(typeof data).toBe('object');
+
+      expect(data).toEqual({ result: 'ok' });
     });
 
     it('应该处理文本响应', async () => {
-      const response = await proxyFetch('https://httpbin.org/robots.txt');
-      const text = await response.text();
-      expect(typeof text).toBe('string');
-      expect(text.length).toBeGreaterThan(0);
+      undiciMocks.fetch.mockResolvedValueOnce(new Response('robots content'));
+
+      const response = await proxyFetch('https://example.test/robots.txt');
+
+      await expect(response.text()).resolves.toBe('robots content');
     });
   });
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,6 +1,30 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
+const isCI = process.env.CI === 'true';
+const threadPool = {
+  pool: 'threads' as const,
+  fileParallelism: !isCI,
+  poolOptions: {
+    threads: {
+      singleThread: isCI,
+      maxThreads: isCI ? 1 : 4,
+      minThreads: 1,
+    },
+  },
+};
+const forkPool = {
+  pool: 'forks' as const,
+  fileParallelism: !isCI,
+  poolOptions: {
+    forks: {
+      singleFork: isCI,
+      maxForks: isCI ? 1 : 4,
+      minForks: 1,
+    },
+  },
+};
+
 export default defineConfig({
   test: {
     globals: true,
@@ -40,23 +64,13 @@ export default defineConfig({
       NODE_ENV: 'test',
       TEST_MODE: 'true',
     },
-    pool: process.env.CI === 'true' ? 'forks' : 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: process.env.CI === 'true',
-        maxThreads: process.env.CI === 'true' ? 1 : 4,
-        minThreads: 1,
-      },
-      forks: {
-        singleFork: true,
-      },
-    },
-    fileParallelism: process.env.CI === 'true' ? false : true,
+    ...threadPool,
     isolate: true,
     projects: [
       {
         test: {
           name: 'unit',
+          ...threadPool,
           include: ['tests/unit/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           typecheck: {
@@ -69,62 +83,47 @@ export default defineConfig({
       {
         test: {
           name: 'integration',
+          ...forkPool,
           include: ['tests/integration/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           testTimeout: 30000,
           hookTimeout: 30000,
-          poolOptions: {
-            threads: {
-              singleThread: true,
-            },
-          },
         },
       },
       {
         test: {
           name: 'cli',
+          ...threadPool,
           include: ['tests/integration/cli/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           testTimeout: 30000,
           hookTimeout: 30000,
-          poolOptions: {
-            threads: {
-              singleThread: true,
-            },
-          },
         },
       },
       {
         test: {
           name: 'e2e',
+          ...forkPool,
           include: ['tests/e2e/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts', './tests/support/setup.e2e.ts'],
           testTimeout: 60000,
           hookTimeout: 60000,
-          poolOptions: {
-            threads: {
-              singleThread: true,
-            },
-          },
         },
       },
       {
         test: {
           name: 'performance',
+          ...threadPool,
           include: ['tests/performance/**/*.{test,spec,bench}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           testTimeout: 120000,
           hookTimeout: 120000,
-          poolOptions: {
-            threads: {
-              singleThread: true,
-            },
-          },
         },
       },
       {
         test: {
           name: 'snapshot',
+          ...threadPool,
           include: ['tests/snapshots/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           testTimeout: 15000,
@@ -134,15 +133,11 @@ export default defineConfig({
       {
         test: {
           name: 'security',
+          ...forkPool,
           include: ['tests/security/**/*.{test,spec}.{js,ts,jsx,tsx}'],
           setupFiles: ['./tests/support/setup.ts'],
           testTimeout: 30000,
           hookTimeout: 30000,
-          poolOptions: {
-            threads: {
-              singleThread: true,
-            },
-          },
         },
       },
     ],

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
       },
     },
     fileParallelism: process.env.CI === 'true' ? false : true,
-    isolate: process.env.CI === 'true' ? false : true,
+    isolate: true,
     projects: [
       {
         test: {


### PR DESCRIPTION
## What changed

- restore Vitest file isolation and preserve real node:fs exports in the subagent registry mock
- fix production and test TypeScript errors reported by run 30558555604
- add a local node-pty declaration for CI installs where the optional native package is unavailable

## Root cause

CI disabled Vitest isolation, allowing a full node:fs mock to leak into SessionRuntime tests. The type gate also exposed accumulated strict TypeScript errors in runtime adapters and test doubles.

## Verification

- CI=true NODE_ENV=test bun run type-check
- CI=true NODE_ENV=test bun run test:headless-core (49 tests)
- focused affected Vitest suite (53 tests)
- Quality Gate equivalent build, web lint, web tests, and workspace build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resume options now support both session identifiers and boolean values.
  - Hook configurations include support for HTTP policy settings by default.
  - Improved terminal process integration and ACP stream compatibility.

- **Bug Fixes**
  - Improved reliability when terminating background tasks and handling interrupted operations.

- **Tests**
  - Expanded coverage for proxy requests, timeouts, abort handling, UI rendering, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->