### PR TITLE
fix(release): make tag workflow the single npm publisher

### DIFF
--- a/packages/cli/release.config.js
+++ b/packages/cli/release.config.js
@@ -52,8 +52,8 @@ export default {
   
   // 发布配置
   publish: {
-    // 是否发布到 npm
-    npm: true,
+    // npm 发布由 tag workflow 统一负责，避免本地脚本与 CI 重复发布
+    npm: false,
     // npm 发布配置
     npmConfig: {
       access: 'public',
@@ -94,4 +94,4 @@ export default {
       failure: '❌ 版本 {{version}} 发布失败：{{error}}',
     },
   },
-}; 
+};

--- a/packages/cli/release.config.js
+++ b/packages/cli/release.config.js
@@ -86,7 +86,7 @@ export default {
     methods: ['console', 'discord'],
     // Discord 配置
     discord: {
-      webhookUrl: process.env.DISCORD_WEBHOOK_URL || 'https://discord.com/api/webhooks/1460226980938125387/5fWgMuGmkGtb6j3eoDaz4JtSFfH8LtFtHK9F2srIHGoXp71zm4sHFPCc729PujDbHJ2F',
+      webhookUrl: process.env.DISCORD_WEBHOOK_URL,
     },
     // 通知模板
     templates: {

--- a/packages/cli/tests/unit/scripts/release-config.test.ts
+++ b/packages/cli/tests/unit/scripts/release-config.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+describe('release ownership contract', () => {
+  it('publishes npm only from the tag workflow', async () => {
+    const configPath = path.resolve(__dirname, '../../../release.config.js');
+    const { default: releaseConfig } = (await import(
+      pathToFileURL(configPath).href
+    )) as {
+      default: { publish: { npm: boolean; git: boolean } };
+    };
+    const publishWorkflow = fs.readFileSync(
+      path.resolve(__dirname, '../../../../../.github/workflows/publish.yml'),
+      'utf8'
+    );
+
+    expect(releaseConfig.publish.npm).toBe(false);
+    expect(releaseConfig.publish.git).toBe(true);
+    expect(publishWorkflow).toContain("- 'v*.*.*'");
+    expect(publishWorkflow).toContain('npm publish --access public');
+  });
+});

--- a/packages/cli/tests/unit/scripts/release-config.test.ts
+++ b/packages/cli/tests/unit/scripts/release-config.test.ts
@@ -3,31 +3,55 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+const configPath = path.resolve(__dirname, '../../../release.config.js');
+const workflowsPath = path.resolve(__dirname, '../../../../../.github/workflows');
+
+async function loadReleaseConfig(cacheKey: string) {
+  return (await import(`${pathToFileURL(configPath).href}?${cacheKey}`)).default as {
+    publish: { npm: boolean; git: boolean };
+    notifications: { discord: { webhookUrl?: string } };
+  };
+}
+
 describe('release ownership contract', () => {
   it('publishes npm only from the tag workflow', async () => {
-    const configPath = path.resolve(__dirname, '../../../release.config.js');
-    const { default: releaseConfig } = (await import(
-      pathToFileURL(configPath).href
-    )) as {
-      default: { publish: { npm: boolean; git: boolean } };
-    };
+    const releaseConfig = await loadReleaseConfig('publish-owner');
+    const workflowFiles = fs
+      .readdirSync(workflowsPath)
+      .filter((file) => /\.ya?ml$/.test(file));
+    const npmPublishers = workflowFiles.filter((file) =>
+      fs.readFileSync(path.join(workflowsPath, file), 'utf8').includes('npm publish')
+    );
     const publishWorkflow = fs.readFileSync(
-      path.resolve(__dirname, '../../../../../.github/workflows/publish.yml'),
+      path.join(workflowsPath, 'publish.yml'),
       'utf8'
     );
 
     expect(releaseConfig.publish.npm).toBe(false);
     expect(releaseConfig.publish.git).toBe(true);
+    expect(npmPublishers).toEqual(['publish.yml']);
     expect(publishWorkflow).toContain("- 'v*.*.*'");
     expect(publishWorkflow).toContain('npm publish --access public');
   });
 
-  it('does not ship notification credentials in source', () => {
-    const configSource = fs.readFileSync(
-      path.resolve(__dirname, '../../../release.config.js'),
-      'utf8'
-    );
+  it('loads notification credentials only from the environment', async () => {
+    const previousWebhook = process.env.DISCORD_WEBHOOK_URL;
+    process.env.DISCORD_WEBHOOK_URL = 'https://example.invalid/test-webhook';
 
-    expect(/https:\/\/discord\.com\/api\/webhooks\//.test(configSource)).toBe(false);
+    try {
+      const releaseConfig = await loadReleaseConfig('notification-env');
+      const configSource = fs.readFileSync(configPath, 'utf8');
+
+      expect(releaseConfig.notifications.discord.webhookUrl).toBe(
+        'https://example.invalid/test-webhook'
+      );
+      expect(/https:\/\/discord\.com\/api\/webhooks\//.test(configSource)).toBe(false);
+    } finally {
+      if (previousWebhook === undefined) {
+        delete process.env.DISCORD_WEBHOOK_URL;
+      } else {
+        process.env.DISCORD_WEBHOOK_URL = previousWebhook;
+      }
+    }
   });
 });

--- a/packages/cli/tests/unit/scripts/release-config.test.ts
+++ b/packages/cli/tests/unit/scripts/release-config.test.ts
@@ -21,4 +21,13 @@ describe('release ownership contract', () => {
     expect(publishWorkflow).toContain("- 'v*.*.*'");
     expect(publishWorkflow).toContain('npm publish --access public');
   });
+
+  it('does not ship notification credentials in source', () => {
+    const configSource = fs.readFileSync(
+      path.resolve(__dirname, '../../../release.config.js'),
+      'utf8'
+    );
+
+    expect(/https:\/\/discord\.com\/api\/webhooks\//.test(configSource)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- make the tag-triggered workflow the only npm publisher
- keep local release scripts responsible for versioning, tagging, and pushing
- require Discord notification credentials through `DISCORD_WEBHOOK_URL` instead of shipping a source default

## Verification
- `bun x vitest run --config vitest.config.ts --project unit tests/unit/scripts/release-config.test.ts`
- `bun x biome check release.config.js tests/unit/scripts/release-config.test.ts`
- `bun x tsc --noEmit --pretty false`
- `bun run release:minor --dry-run` (resolved `0.7.0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented local release scripts from publishing packages to npm.
  * Removed embedded Discord webhook credentials; release notifications now require configured credentials.
  * Ensured public npm publishing occurs through the designated tag-based workflow.

* **Tests**
  * Added release configuration checks covering publishing behavior and credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->